### PR TITLE
feat: adding the Roles and permission API with the documentation

### DIFF
--- a/Postman-API-Test-RolesAndPermissions-Auth.md
+++ b/Postman-API-Test-RolesAndPermissions-Auth.md
@@ -1,0 +1,502 @@
+# Postman API Test
+
+## Table of Contents
+- [Base URL](#base-url)
+- [Required](#required)
+- [Authentication](#authentication)
+- [Endpoints](#)
+- [Resources](#)
+
+## Base URL
+
+[Back](#table-of-contents)
+
+`http://faceoff-2025-s1.test/api/v1`
+
+## Required
+
+[Back](#table-of-contents)
+
+- Add Header `Key`: accept, `Value`: application/json
+- Set Body `raw`, `JSON`
+
+> [!NOTE]
+> If endpoint required token,
+> - Set Authorization `Bearer Token`
+> - Add User's `Token`
+
+## Authentication 
+Some of the endpoints require the authentication to work properly, so for this you need:
+- Follow the guide in [User Auth Guide](Postman-API-Test-User-Auth.md)
+- Register and login to obtain the user token.
+- Use this token in the Authorization header.
+
+## Endpoints
+### Get /roles
+In this endpoint I get the roles with the permissions for each role.
+
+1. Super Admin
+
+<details>
+
+```json
+{
+    "id": 1,
+    "name": "Super Admin",
+    "guard_name": "web",
+    "created_at": "2025-05-08T09:02:07.000000Z",
+    "updated_at": "2025-05-08T09:02:07.000000Z",
+    "permissions": [
+        {
+            "id": 1,
+            "name": "System-Configuration",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:06.000000Z",
+            "updated_at": "2025-05-08T09:02:06.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 1
+            }
+        },
+        {
+            "id": 2,
+            "name": "Manage-Roles",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:06.000000Z",
+            "updated_at": "2025-05-08T09:02:06.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 2
+            }
+        },
+        {
+            "id": 3,
+            "name": "Manage-Domains",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:06.000000Z",
+            "updated_at": "2025-05-08T09:02:06.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 3
+            }
+        },
+        {
+            "id": 4,
+            "name": "User Management",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:06.000000Z",
+            "updated_at": "2025-05-08T09:02:06.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 4
+            }
+        },
+        {
+            "id": 5,
+            "name": "Backup Management",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:07.000000Z",
+            "updated_at": "2025-05-08T09:02:07.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 5
+            }
+        },
+        {
+            "id": 6,
+            "name": "Import/Export",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:07.000000Z",
+            "updated_at": "2025-05-08T09:02:07.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 6
+            }
+        },
+        {
+            "id": 7,
+            "name": "Class-Session-Management",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:07.000000Z",
+            "updated_at": "2025-05-08T09:02:07.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 7
+            }
+        },
+        {
+            "id": 8,
+            "name": "Approve-Changes",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:07.000000Z",
+            "updated_at": "2025-05-08T09:02:07.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 8
+            }
+        },
+        {
+            "id": 9,
+            "name": "View-All-Class-Sessions",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:07.000000Z",
+            "updated_at": "2025-05-08T09:02:07.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 9
+            }
+        },
+        {
+            "id": 11,
+            "name": "Edit-Own-Profile",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:07.000000Z",
+            "updated_at": "2025-05-08T09:02:07.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 11
+            }
+        },
+        {
+            "id": 12,
+            "name": "Request-Changes",
+            "guard_name": "web",
+            "created_at": "2025-05-08T09:02:07.000000Z",
+            "updated_at": "2025-05-08T09:02:07.000000Z",
+            "pivot": {
+                "role_id": 1,
+                "permission_id": 12
+            }
+        }
+    ]
+}
+```
+</details>
+
+2. Admin
+
+<details>
+
+```json
+{
+        "id": 2,
+        "name": "Admin",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z",
+        "permissions": [
+            {
+                "id": 3,
+                "name": "Manage-Domains",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:06.000000Z",
+                "updated_at": "2025-05-08T09:02:06.000000Z",
+                "pivot": {
+                    "role_id": 2,
+                    "permission_id": 3
+                }
+            },
+            {
+                "id": 4,
+                "name": "User Management",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:06.000000Z",
+                "updated_at": "2025-05-08T09:02:06.000000Z",
+                "pivot": {
+                    "role_id": 2,
+                    "permission_id": 4
+                }
+            },
+            {
+                "id": 5,
+                "name": "Backup Management",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 2,
+                    "permission_id": 5
+                }
+            },
+            {
+                "id": 6,
+                "name": "Import/Export",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 2,
+                    "permission_id": 6
+                }
+            },
+            {
+                "id": 7,
+                "name": "Class-Session-Management",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 2,
+                    "permission_id": 7
+                }
+            },
+            {
+                "id": 8,
+                "name": "Approve-Changes",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 2,
+                    "permission_id": 8
+                }
+            },
+            {
+                "id": 9,
+                "name": "View-All-Class-Sessions",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 2,
+                    "permission_id": 9
+                }
+            },
+            {
+                "id": 11,
+                "name": "Edit-Own-Profile",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 2,
+                    "permission_id": 11
+                }
+            },
+            {
+                "id": 12,
+                "name": "Request-Changes",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 2,
+                    "permission_id": 12
+                }
+            }
+        ]
+    }
+```
+</details>
+
+3. Staff
+
+<details>
+
+```Json
+{
+        "id": 3,
+        "name": "Staff",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z",
+        "permissions": [
+            {
+                "id": 7,
+                "name": "Class-Session-Management",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 3,
+                    "permission_id": 7
+                }
+            },
+            {
+                "id": 8,
+                "name": "Approve-Changes",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 3,
+                    "permission_id": 8
+                }
+            },
+            {
+                "id": 10,
+                "name": "View-Own-Class-Sessions",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 3,
+                    "permission_id": 10
+                }
+            },
+            {
+                "id": 11,
+                "name": "Edit-Own-Profile",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 3,
+                    "permission_id": 11
+                }
+            },
+            {
+                "id": 12,
+                "name": "Request-Changes",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 3,
+                    "permission_id": 12
+                }
+            }
+        ]
+    }
+```
+</details>
+
+4. Student
+
+<details>
+
+```Json
+{
+        "id": 4,
+        "name": "Student",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z",
+        "permissions": [
+            {
+                "id": 11,
+                "name": "Edit-Own-Profile",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 4,
+                    "permission_id": 11
+                }
+            },
+            {
+                "id": 12,
+                "name": "Request-Changes",
+                "guard_name": "web",
+                "created_at": "2025-05-08T09:02:07.000000Z",
+                "updated_at": "2025-05-08T09:02:07.000000Z",
+                "pivot": {
+                    "role_id": 4,
+                    "permission_id": 12
+                }
+            }
+        ]
+    }
+```
+</details>
+
+### Get /permissions
+In this endpoint I get the permissions with the information:
+
+```Json
+{
+        "id": 1,
+        "name": "System-Configuration",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:06.000000Z",
+        "updated_at": "2025-05-08T09:02:06.000000Z"
+    },
+    {
+        "id": 2,
+        "name": "Manage-Roles",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:06.000000Z",
+        "updated_at": "2025-05-08T09:02:06.000000Z"
+    },
+    {
+        "id": 3,
+        "name": "Manage-Domains",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:06.000000Z",
+        "updated_at": "2025-05-08T09:02:06.000000Z"
+    },
+    {
+        "id": 4,
+        "name": "User Management",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:06.000000Z",
+        "updated_at": "2025-05-08T09:02:06.000000Z"
+    },
+    {
+        "id": 5,
+        "name": "Backup Management",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z"
+    },
+    {
+        "id": 6,
+        "name": "Import/Export",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z"
+    },
+    {
+        "id": 7,
+        "name": "Class-Session-Management",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z"
+    },
+    {
+        "id": 8,
+        "name": "Approve-Changes",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z"
+    },
+    {
+        "id": 9,
+        "name": "View-All-Class-Sessions",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z"
+    },
+    {
+        "id": 10,
+        "name": "View-Own-Class-Sessions",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z"
+    },
+    {
+        "id": 11,
+        "name": "Edit-Own-Profile",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z"
+    },
+    {
+        "id": 12,
+        "name": "Request-Changes",
+        "guard_name": "web",
+        "created_at": "2025-05-08T09:02:07.000000Z",
+        "updated_at": "2025-05-08T09:02:07.000000Z"
+    }
+```
+
+## Resources
+- [User Auth Guide](Postman-API-Test-User-Auth.md)
+
+
+
+
+
+
+
+

--- a/app/Http/Controllers/Api/v1/PermissionController.php
+++ b/app/Http/Controllers/Api/v1/PermissionController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Spatie\Permission\Models\Permission;
+
+class PermissionController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return Permission::all();
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|unique:permissions,name',
+        ]);
+
+        return Permission::create(['name' => $request->name]);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Permission $permission)
+    {
+        return $permission;
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Permission $permission)
+    {
+        $request->validate([
+            'name' => 'required|unique:permissions,name,' . $permission->id,
+        ]);
+
+        $permission->update(['name' => $request->name]);
+
+        return $permission;
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Permission $permission)
+    {
+        $permission->delete();
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/v1/RoleController.php
+++ b/app/Http/Controllers/Api/v1/RoleController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Api\v1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+
+class RoleController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return Role::with('permissions')->get();
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|unique:roles,name',
+            'permissions' => 'array'
+        ]);
+
+        $role = Role::create(['name' => $request->name]);
+
+        if ($request->has('permissions')) {
+            $role->syncPermissions($request->permissions);
+        }
+
+        return response()->json($role->load('permissions'), 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Role $role)
+    {
+        return $role->load('permissions');
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Role $role)
+    {
+        $request->validate([
+            'name' => 'sometimes|unique:roles,name,' . $role->id,
+            'permissions' => 'array'
+        ]);
+
+        $role->update($request->only('name'));
+
+        if ($request->has('permissions')) {
+            $role->syncPermissions($request->permissions);
+        }
+
+        return $role->load('permissions');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Role $role)
+    {
+        $role->delete();
+        return response()->noContent();
+    }
+}

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Api\v1\CourseController;
 use App\Http\Controllers\Api\v1\ClusterController;
 use App\Http\Controllers\Api\v1\UnitController;
 use App\Http\Controllers\Api\v1\UserController;
+use App\Http\Controllers\Api\v1\RoleController;
+use App\Http\Controllers\Api\v1\PermissionController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -23,9 +25,9 @@ Route::group(['prefix'=> 'auth'], function () {
     return $request->user();
   })->middleware('auth:sanctum');
   Route::post('/register', [AuthController::class, 'register']);
-  Route::post('/login', [AuthController::class, 'login']);
-  Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');
+    Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');
 });
+Route::post('/login', [AuthController::class, 'login']);
 
 /**
  * Users API Routes
@@ -61,3 +63,15 @@ Route::apiResource('clusters', ClusterController::class);
  *  - Update, Destroy (Auth required)
  */
 Route::apiResource('units', UnitController::class);
+
+/**
+ * Roles API Routes
+ *  - Index, Create, Show, Update, Destroy (Auth required)
+ */
+Route::apiResource('roles', RoleController::class)->middleware('auth:sanctum');
+
+/**
+ * Permissions API Routes
+ *  - Index, Create, Show, Update, Destroy (Auth required)
+ */
+Route::apiResource('permissions', PermissionController::class)->middleware('auth:sanctum');


### PR DESCRIPTION
In this pull request I add the API for roles and permission in the api v1 folder and the corresponding documentation with the postman response.