### PR TITLE
test(ClassSession): add complete API tests for ClassSessionController

### DIFF
--- a/tests/Feature/Api/v1/ClassSessionTest.php
+++ b/tests/Feature/Api/v1/ClassSessionTest.php
@@ -5,6 +5,7 @@ use App\Models\Cluster;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
+
 /**
  * This will reset this database after each of those tests so that data from a previous test does
  * not interfere with subsequent tests.
@@ -25,138 +26,150 @@ uses(RefreshDatabase::class);
  * https://laravel.com/docs/12.x/http-tests#session-authentication
  */
 beforeEach(function () {
-    $this->session = ClassSession::factory()->count(21)->create();
-    $this->cluster = Cluster::factory()->create();
     $this->staff = User::factory()->create(['role' => 'staff']);
-    $this->actingAs($this->staff);
+    $this->targetStudents = 5;
+    $this->students = User::factory()->count($this->targetStudents)->create(['role' => 'student']);
+    $this->cluster = Cluster::factory()->create();
+    $this->actingAs($this->staff, 'sanctum');
+    $this->targetCounts = 21;
+    $this->classSession = ClassSession::factory()->count($this->targetCounts)->create();
 });
 
+
 /**
- * Test that the class session index page loads successfully.
+ * Test that the API returns all class sessions in JSON format.
+ * 
+ * GET /api/v1/class-sessions
  */
-test('displays the class session index page', function () {
-    $this->get('/class-sessions')
+test('api returns all class sessions', function () {
+    $response = $this->getJson('/api/v1/class-sessions')
         ->assertOk()
-        ->assertViewIs('class_sessions.index');
+        ->assertJsonStructure(['success', 'data', 'message']);
+
+    expect(count($response->json('data')))->toBe($this->targetCounts);
 });
 
-/**
- * Test that class sessions are paginated properly on the index view.
- */
-test('paginates class sessions correctly', function () {
-    $response = $this->get(route('class_sessions.index'));
-    $pages = $response->viewData('classSessions');
-
-    $this->assertEquals(3, $pages->lastPage());
-});
 
 /**
- * Test that the create form for class sessions is displayed.
+ * Test that a new class session is stored successfully via API with valid data, including student IDs.
+ * 
+ * POST /api/v1/class-sessions
  */
-test('shows the create class session form', function () {
-    $this->get('/class-sessions/create')
-        ->assertOk()
-        ->assertViewIs('class_sessions.create');
-});
-
-/**
- * Test that a class session is stored successfully with valid data.
- */
-test('stores a class session successfully', function () {
-    $this->post(route('class_sessions.store'), [
-        'title' => 'Session 1',
+test('api stores a new class session with students', function () {
+    $response = $this->postJson('/api/v1/class-sessions', [
+        'title' => 'API Session',
         'cluster_id' => $this->cluster->id,
         'user_id' => $this->staff->id,
-        'start_date' => '2025-06-01',
-        'end_date' => '2025-06-10',
-    ])->assertRedirect(route('class_sessions.index'));
-    expect(ClassSession::count())->toBe(22);
+        'start_date' => '2025-07-01',
+        'end_date' => '2025-12-31',
+        'students' => $this->students->pluck('id')->toArray(),
+    ]);
+
+    $response->assertCreated()
+        ->assertJsonFragment([
+            'title' => 'API Session',
+            'cluster_id' => $this->cluster->id,
+            'user_id' => $this->staff->id,
+        ])->assertJsonStructure([
+            'success',
+            'data' => [
+                'id',
+                'title',
+                'cluster',
+                'staff',
+                'students',
+                'start_date',
+                'end_date'
+            ],
+            'message',
+        ]);
 });
 
-/**
- * Test that validation errors are triggered when storing with invalid data.
- */
-test('fails to store a class session with invalid data', function () {
-    $this->post(route('class_sessions.store'), [])
-        ->assertSessionHasErrors(['title', 'cluster_id', 'user_id', 'start_date', 'end_date']);
-});
 
 /**
- * Test that a class session detail page is shown successfully.
+ * Test that validation errors are returned if required fields are missing when storing a class session.
+ *  
+ * POST /api/v1/class-sessions
  */
-test('shows a class session detail page', function () {
-    $this->get(route('class_sessions.show', $this->session[0]->id))
+test('api fails to store with invalid input', function () {
+    $this->postJson('/api/v1/class-sessions', [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['title', 'cluster_id', 'user_id', 'start_date', 'end_date']);
+});
+
+
+/**
+ * Test that a specific class session can be retrieved successfully by ID.
+ * 
+ * GET /api/v1/class-sessions/{id}
+ */
+test('api shows a specific class session', function () {
+    $this->getJson("/api/v1/class-sessions/{$this->classSession[0]->id}")
         ->assertOk()
-        ->assertViewIs('class_sessions.show');
+        ->assertJsonFragment(['id' => $this->classSession[0]->id]);
 });
 
-/**
- * Test that attempting to show a non-existent session redirects to index.
- */
-test('redirects when trying to show a non-existent class session', function () {
-    $this->get(route('class_sessions.show', 999))
-        ->assertRedirect(route('class_sessions.index'))
-        ->assertSessionHas('error');
-});
 
 /**
- * Test that the edit form for a class session is shown.
+ * Test that a 404 response is returned if trying to access a non-existent class session.
+ * 
+ * GET /api/v1/class-sessions/{id}
  */
-test('shows the edit form for a class session', function () {
-    $this->get(route('class_sessions.edit', $this->session[0]->id))
-        ->assertOk()
-        ->assertViewIs('class_sessions.update');
+test('api returns 404 when class session is not found', function () {
+    $this->getJson('/api/v1/class-sessions/-1')
+        ->assertStatus(404);
 });
 
-/**
- * Test that all necessary data is passed to the edit view.
- */
-test('edit view has all necessary data', function () {
-    $this->get(route('class_sessions.edit', $this->session[0]->id))
-        ->assertViewHasAll(['classSession', 'staff', 'clusters', 'students']);
-});
 
 /**
- * Test that a class session is updated successfully with valid data.
+ * Test that a class session is updated successfully with valid input via API.
+ * 
+ * PUT /api/v1/class-sessions/{id}
  */
-test('updates a class session successfully', function () {
-    $this->put(route('class_sessions.update', $this->session[0]), [
-        'title' => 'Updated Session',
+test('api updates a class session successfully', function () {
+    $this->putJson("/api/v1/class-sessions/{$this->classSession[0]->id}", [
+        'title' => 'Updated API Title',
         'cluster_id' => $this->cluster->id,
         'user_id' => $this->staff->id,
-        'start_date' => '2025-06-05',
-        'end_date' => '2025-06-15',
-    ])->assertRedirect(route('class_sessions.index'));
-
-    $this->session[0]->refresh();
-    expect($this->session[0]->title)->toBe('Updated Session');
+        'start_date' => '2025-08-01',
+        'end_date' => '2025-08-10',
+        'students' => $this->students->pluck('id')->toArray(),
+    ])
+        ->assertOk()
+        ->assertJsonFragment(['title' => 'Updated API Title']);
 });
 
+
 /**
- * Test that validation errors occur if update request is missing fields.
+ * Test that a class session is updated successfully with valid input via API.
+ * 
+ * PUT /api/v1/class-sessions/{id}
  */
-test('fails to update with missing required fields', function () {
-    $this->put(route('class_sessions.update', $this->session[0]), [])
-        ->assertSessionHasErrors(['title', 'cluster_id', 'user_id', 'start_date', 'end_date']);
+test('api fails to update with invalid data', function () {
+    $this->putJson("/api/v1/class-sessions/{$this->classSession[0]->id}", [])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors(['title', 'cluster_id', 'user_id', 'start_date', 'end_date']);
 });
 
-/**
- * Test that a class session is deleted properly.
- */
-test('deletes a class session', function () {
-    $this->delete(route('class_sessions.destroy', $this->session[0]))
-        ->assertRedirect(route('class_sessions.index'));
 
-    expect(ClassSession::count())->toBe(20);
+/**
+ * Test that a class session is deleted successfully via API.
+ * 
+ * DELETE /api/v1/class-sessions/{id}
+ */
+test('api deletes a class session successfully', function () {
+    $this->deleteJson("/api/v1/class-sessions/{$this->classSession[0]->id}")
+        ->assertOk()
+        ->assertJson(['message' => 'Class session deleted successfully']);
 });
 
-/**
- * Test that deleting a session that was already deleted is handled gracefully.
- */
-test('handles delete gracefully if session already deleted', function () {
-    $this->delete(route('class_sessions.destroy', $this->session[0]->id))
-         ->assertRedirect(route('class_sessions.index'));
 
-    $this->delete(route('class_sessions.destroy', $this->session[0]->id))
-         ->assertStatus(404);
+/**
+ * Test that a 404 response is returned if trying to delete a non-existent class session.
+ * 
+ * DELETE /api/v1/class-sessions/{id}
+ */
+test('api returns 404 if trying to delete non-existent session', function () {
+    $this->deleteJson('/api/v1/class-sessions/999')
+        ->assertStatus(404);
 });

--- a/tests/Feature/Web/v1/ClassSessionTest.php
+++ b/tests/Feature/Web/v1/ClassSessionTest.php
@@ -1,0 +1,162 @@
+<?php
+
+use App\Models\ClassSession;
+use App\Models\Cluster;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * This will reset this database after each of those tests so that data from a previous test does
+ * not interfere with subsequent tests.
+ * 
+ * https://laravel.com/docs/12.x/database-testing
+ */
+uses(RefreshDatabase::class);
+
+
+/**
+ * Create and login a user for testing page required auth
+ * 
+ * What is `beforeEach` ?
+ * Executes the provided closure before every test within the current file, 
+ * ensuring that any necessary setup or configuration is completed before each test.
+ * 
+ * https://pestphp.com/docs/hooks#beforeeach
+ * https://laravel.com/docs/12.x/http-tests#session-authentication
+ */
+beforeEach(function () {
+    $this->session = ClassSession::factory()->count(21)->create();
+    $this->cluster = Cluster::factory()->create();
+    $this->staff = User::factory()->create(['role' => 'staff']);
+    $this->actingAs($this->staff);
+});
+
+/**
+ * Test that the class session index page loads successfully.
+ */
+test('displays the class session index page', function () {
+    $this->get('/class-sessions')
+        ->assertOk()
+        ->assertViewIs('class_sessions.index');
+});
+
+/**
+ * Test that class sessions are paginated properly on the index view.
+ */
+test('paginates class sessions correctly', function () {
+    $response = $this->get(route('class_sessions.index'));
+    $pages = $response->viewData('classSessions');
+
+    $this->assertEquals(3, $pages->lastPage());
+});
+
+/**
+ * Test that the create form for class sessions is displayed.
+ */
+test('shows the create class session form', function () {
+    $this->get('/class-sessions/create')
+        ->assertOk()
+        ->assertViewIs('class_sessions.create');
+});
+
+/**
+ * Test that a class session is stored successfully with valid data.
+ */
+test('stores a class session successfully', function () {
+    $this->post(route('class_sessions.store'), [
+        'title' => 'Session 1',
+        'cluster_id' => $this->cluster->id,
+        'user_id' => $this->staff->id,
+        'start_date' => '2025-06-01',
+        'end_date' => '2025-06-10',
+    ])->assertRedirect(route('class_sessions.index'));
+    expect(ClassSession::count())->toBe(22);
+});
+
+/**
+ * Test that validation errors are triggered when storing with invalid data.
+ */
+test('fails to store a class session with invalid data', function () {
+    $this->post(route('class_sessions.store'), [])
+        ->assertSessionHasErrors(['title', 'cluster_id', 'user_id', 'start_date', 'end_date']);
+});
+
+/**
+ * Test that a class session detail page is shown successfully.
+ */
+test('shows a class session detail page', function () {
+    $this->get(route('class_sessions.show', $this->session[0]->id))
+        ->assertOk()
+        ->assertViewIs('class_sessions.show');
+});
+
+/**
+ * Test that attempting to show a non-existent session redirects to index.
+ */
+test('redirects when trying to show a non-existent class session', function () {
+    $this->get(route('class_sessions.show', 999))
+        ->assertRedirect(route('class_sessions.index'))
+        ->assertSessionHas('error');
+});
+
+/**
+ * Test that the edit form for a class session is shown.
+ */
+test('shows the edit form for a class session', function () {
+    $this->get(route('class_sessions.edit', $this->session[0]->id))
+        ->assertOk()
+        ->assertViewIs('class_sessions.update');
+});
+
+/**
+ * Test that all necessary data is passed to the edit view.
+ */
+test('edit view has all necessary data', function () {
+    $this->get(route('class_sessions.edit', $this->session[0]->id))
+        ->assertViewHasAll(['classSession', 'staff', 'clusters', 'students']);
+});
+
+/**
+ * Test that a class session is updated successfully with valid data.
+ */
+test('updates a class session successfully', function () {
+    $this->put(route('class_sessions.update', $this->session[0]), [
+        'title' => 'Updated Session',
+        'cluster_id' => $this->cluster->id,
+        'user_id' => $this->staff->id,
+        'start_date' => '2025-06-05',
+        'end_date' => '2025-06-15',
+    ])->assertRedirect(route('class_sessions.index'));
+
+    $this->session[0]->refresh();
+    expect($this->session[0]->title)->toBe('Updated Session');
+});
+
+/**
+ * Test that validation errors occur if update request is missing fields.
+ */
+test('fails to update with missing required fields', function () {
+    $this->put(route('class_sessions.update', $this->session[0]), [])
+        ->assertSessionHasErrors(['title', 'cluster_id', 'user_id', 'start_date', 'end_date']);
+});
+
+/**
+ * Test that a class session is deleted properly.
+ */
+test('deletes a class session', function () {
+    $this->delete(route('class_sessions.destroy', $this->session[0]))
+        ->assertRedirect(route('class_sessions.index'));
+
+    expect(ClassSession::count())->toBe(20);
+});
+
+/**
+ * Test that deleting a session that was already deleted is handled gracefully.
+ */
+test('handles delete gracefully if session already deleted', function () {
+    $this->delete(route('class_sessions.destroy', $this->session[0]->id))
+         ->assertRedirect(route('class_sessions.index'));
+
+    $this->delete(route('class_sessions.destroy', $this->session[0]->id))
+         ->assertStatus(404);
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive Pest-powered API tests for the ClassSession CRUD endpoints (`/api/v1/class-sessions`). These tests ensure full coverage of core functionalities, including successful requests, validation errors, and error handling.

### Key Changes
- Covers the Pest API test issue (#35)
- Moves previously created web-based tests into the `tests/Feature/Web/v1` directory
- Adds new API tests under `tests/Feature/Api/v1`
