### PR TITLE
chore: Add missing Auth import to StoreRoleRequest

### DIFF
--- a/app/Http/Requests/v1/StoreRoleRequest.php
+++ b/app/Http/Requests/v1/StoreRoleRequest.php
@@ -2,8 +2,9 @@
 
 namespace App\Http\Requests\v1;
 
-use Illuminate\Foundation\Http\FormRequest;
 use Spatie\Permission\Models\Role;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Foundation\Http\FormRequest;
 
 class StoreRoleRequest extends FormRequest
 {


### PR DESCRIPTION
Ensures the Auth facade is correctly imported for potential future use or existing but uncommented logic within the request.